### PR TITLE
Remove legacy charts - Leave Pydeck for Maps

### DIFF
--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -17,37 +17,37 @@
  * under the License.
  */
 import { isFeatureEnabled, Preset, FeatureFlag } from '@superset-ui/core';
-import CalendarChartPlugin from '@superset-ui/legacy-plugin-chart-calendar';
-import ChordChartPlugin from '@superset-ui/legacy-plugin-chart-chord';
-import CountryMapChartPlugin from '@superset-ui/legacy-plugin-chart-country-map';
-import EventFlowChartPlugin from '@superset-ui/legacy-plugin-chart-event-flow';
-import HeatmapChartPlugin from '@superset-ui/legacy-plugin-chart-heatmap';
-import HistogramChartPlugin from '@superset-ui/legacy-plugin-chart-histogram';
-import HorizonChartPlugin from '@superset-ui/legacy-plugin-chart-horizon';
-import MapBoxChartPlugin from '@superset-ui/legacy-plugin-chart-map-box';
-import PairedTTestChartPlugin from '@superset-ui/legacy-plugin-chart-paired-t-test';
-import ParallelCoordinatesChartPlugin from '@superset-ui/legacy-plugin-chart-parallel-coordinates';
-import PartitionChartPlugin from '@superset-ui/legacy-plugin-chart-partition';
-import PivotTableChartPlugin from '@superset-ui/legacy-plugin-chart-pivot-table';
-import RoseChartPlugin from '@superset-ui/legacy-plugin-chart-rose';
-import SankeyChartPlugin from '@superset-ui/legacy-plugin-chart-sankey';
-import SunburstChartPlugin from '@superset-ui/legacy-plugin-chart-sunburst';
-import TableChartPlugin from '@superset-ui/plugin-chart-table';
-import TreemapChartPlugin from '@superset-ui/legacy-plugin-chart-treemap';
-import { WordCloudChartPlugin } from '@superset-ui/plugin-chart-word-cloud';
-import WorldMapChartPlugin from '@superset-ui/legacy-plugin-chart-world-map';
-import {
-  AreaChartPlugin,
-  BarChartPlugin,
-  BubbleChartPlugin,
-  BulletChartPlugin,
-  CompareChartPlugin,
-  DistBarChartPlugin,
-  DualLineChartPlugin,
-  LineChartPlugin,
-  LineMultiChartPlugin,
-  TimePivotChartPlugin,
-} from '@superset-ui/legacy-preset-chart-nvd3';
+// import CalendarChartPlugin from '@superset-ui/legacy-plugin-chart-calendar';
+// import ChordChartPlugin from '@superset-ui/legacy-plugin-chart-chord';
+// import CountryMapChartPlugin from '@superset-ui/legacy-plugin-chart-country-map';
+// import EventFlowChartPlugin from '@superset-ui/legacy-plugin-chart-event-flow';
+// import HeatmapChartPlugin from '@superset-ui/legacy-plugin-chart-heatmap';
+// import HistogramChartPlugin from '@superset-ui/legacy-plugin-chart-histogram';
+// import HorizonChartPlugin from '@superset-ui/legacy-plugin-chart-horizon';
+// import MapBoxChartPlugin from '@superset-ui/legacy-plugin-chart-map-box';
+// import PairedTTestChartPlugin from '@superset-ui/legacy-plugin-chart-paired-t-test';
+// import ParallelCoordinatesChartPlugin from '@superset-ui/legacy-plugin-chart-parallel-coordinates';
+// import PartitionChartPlugin from '@superset-ui/legacy-plugin-chart-partition';
+// import PivotTableChartPlugin from '@superset-ui/legacy-plugin-chart-pivot-table';
+// import RoseChartPlugin from '@superset-ui/legacy-plugin-chart-rose';
+// import SankeyChartPlugin from '@superset-ui/legacy-plugin-chart-sankey';
+// import SunburstChartPlugin from '@superset-ui/legacy-plugin-chart-sunburst';
+// import TableChartPlugin from '@superset-ui/plugin-chart-table';
+// import TreemapChartPlugin from '@superset-ui/legacy-plugin-chart-treemap';
+// import { WordCloudChartPlugin } from '@superset-ui/plugin-chart-word-cloud';
+// import WorldMapChartPlugin from '@superset-ui/legacy-plugin-chart-world-map';
+// import {
+//   AreaChartPlugin,
+//   BarChartPlugin,
+//   BubbleChartPlugin,
+//   BulletChartPlugin,
+//   CompareChartPlugin,
+//   DistBarChartPlugin,
+//   DualLineChartPlugin,
+//   LineChartPlugin,
+//   LineMultiChartPlugin,
+//   TimePivotChartPlugin,
+// } from '@superset-ui/legacy-preset-chart-nvd3';
 import { DeckGLChartPreset } from '@superset-ui/legacy-preset-chart-deckgl';
 import {
   BigNumberChartPlugin,
@@ -79,7 +79,7 @@ import {
   GroupByFilterPlugin,
 } from 'src/filters/components';
 import { PivotTableChartPlugin as PivotTableChartPluginV2 } from '@superset-ui/plugin-chart-pivot-table';
-import { HandlebarsChartPlugin } from '@superset-ui/plugin-chart-handlebars';
+// import { HandlebarsChartPlugin } from '@superset-ui/plugin-chart-handlebars';
 import FilterBoxChartPlugin from '../FilterBox/FilterBoxChartPlugin';
 import TimeTableChartPlugin from '../TimeTable';
 
@@ -95,20 +95,20 @@ export default class MainPreset extends Preset {
       name: 'Legacy charts',
       presets: [new DeckGLChartPreset()],
       plugins: [
-        new AreaChartPlugin().configure({ key: 'area' }),
-        new BarChartPlugin().configure({ key: 'bar' }),
+        // new AreaChartPlugin().configure({ key: 'area' }),
+        // new BarChartPlugin().configure({ key: 'bar' }),
         new BigNumberChartPlugin().configure({ key: 'big_number' }),
         new BigNumberTotalChartPlugin().configure({ key: 'big_number_total' }),
         new EchartsBoxPlotChartPlugin().configure({ key: 'box_plot' }),
-        new BubbleChartPlugin().configure({ key: 'bubble' }),
-        new BulletChartPlugin().configure({ key: 'bullet' }),
-        new CalendarChartPlugin().configure({ key: 'cal_heatmap' }),
-        new ChordChartPlugin().configure({ key: 'chord' }),
-        new CompareChartPlugin().configure({ key: 'compare' }),
-        new CountryMapChartPlugin().configure({ key: 'country_map' }),
-        new DistBarChartPlugin().configure({ key: 'dist_bar' }),
-        new DualLineChartPlugin().configure({ key: 'dual_line' }),
-        new EventFlowChartPlugin().configure({ key: 'event_flow' }),
+        // new BubbleChartPlugin().configure({ key: 'bubble' }),
+        // new BulletChartPlugin().configure({ key: 'bullet' }),
+        // new CalendarChartPlugin().configure({ key: 'cal_heatmap' }),
+        // new ChordChartPlugin().configure({ key: 'chord' }),
+        // new CompareChartPlugin().configure({ key: 'compare' }),
+        // new CountryMapChartPlugin().configure({ key: 'country_map' }),
+        // new DistBarChartPlugin().configure({ key: 'dist_bar' }),
+        // new DualLineChartPlugin().configure({ key: 'dual_line' }),
+        // new EventFlowChartPlugin().configure({ key: 'event_flow' }),
         new FilterBoxChartPlugin().configure({ key: 'filter_box' }),
         new EchartsFunnelChartPlugin().configure({ key: 'funnel' }),
         new EchartsTreemapChartPlugin().configure({ key: 'treemap_v2' }),
@@ -118,27 +118,27 @@ export default class MainPreset extends Preset {
         new EchartsMixedTimeseriesChartPlugin().configure({
           key: 'mixed_timeseries',
         }),
-        new HeatmapChartPlugin().configure({ key: 'heatmap' }),
-        new HistogramChartPlugin().configure({ key: 'histogram' }),
-        new HorizonChartPlugin().configure({ key: 'horizon' }),
-        new LineChartPlugin().configure({ key: 'line' }),
-        new LineMultiChartPlugin().configure({ key: 'line_multi' }),
-        new MapBoxChartPlugin().configure({ key: 'mapbox' }),
-        new PairedTTestChartPlugin().configure({ key: 'paired_ttest' }),
-        new ParallelCoordinatesChartPlugin().configure({ key: 'para' }),
-        new PartitionChartPlugin().configure({ key: 'partition' }),
+        // new HeatmapChartPlugin().configure({ key: 'heatmap' }),
+        // new HistogramChartPlugin().configure({ key: 'histogram' }),
+        // new HorizonChartPlugin().configure({ key: 'horizon' }),
+        // new LineChartPlugin().configure({ key: 'line' }),
+        // new LineMultiChartPlugin().configure({ key: 'line_multi' }),
+        // new MapBoxChartPlugin().configure({ key: 'mapbox' }),
+        // new PairedTTestChartPlugin().configure({ key: 'paired_ttest' }),
+        // new ParallelCoordinatesChartPlugin().configure({ key: 'para' }),
+        // new PartitionChartPlugin().configure({ key: 'partition' }),
         new EchartsPieChartPlugin().configure({ key: 'pie' }),
-        new PivotTableChartPlugin().configure({ key: 'pivot_table' }),
+        // new PivotTableChartPlugin().configure({ key: 'pivot_table' }),
         new PivotTableChartPluginV2().configure({ key: 'pivot_table_v2' }),
-        new RoseChartPlugin().configure({ key: 'rose' }),
-        new SankeyChartPlugin().configure({ key: 'sankey' }),
-        new SunburstChartPlugin().configure({ key: 'sunburst' }),
-        new TableChartPlugin().configure({ key: 'table' }),
-        new TimePivotChartPlugin().configure({ key: 'time_pivot' }),
+        // new RoseChartPlugin().configure({ key: 'rose' }),
+        // new SankeyChartPlugin().configure({ key: 'sankey' }),
+        // new SunburstChartPlugin().configure({ key: 'sunburst' }),
+        // new TableChartPlugin().configure({ key: 'table' }),
+        // new TimePivotChartPlugin().configure({ key: 'time_pivot' }),
         new TimeTableChartPlugin().configure({ key: 'time_table' }),
-        new TreemapChartPlugin().configure({ key: 'treemap' }),
-        new WordCloudChartPlugin().configure({ key: 'word_cloud' }),
-        new WorldMapChartPlugin().configure({ key: 'world_map' }),
+        // new TreemapChartPlugin().configure({ key: 'treemap' }),
+        // new WordCloudChartPlugin().configure({ key: 'word_cloud' }),
+        // new WorldMapChartPlugin().configure({ key: 'world_map' }),
         new EchartsAreaChartPlugin().configure({
           key: 'echarts_area',
         }),
@@ -167,7 +167,7 @@ export default class MainPreset extends Preset {
         new TimeGrainFilterPlugin().configure({ key: 'filter_timegrain' }),
         new EchartsTreeChartPlugin().configure({ key: 'tree_chart' }),
         new EchartsSunburstChartPlugin().configure({ key: 'sunburst_v2' }),
-        new HandlebarsChartPlugin().configure({ key: 'handlebars' }),
+        // new HandlebarsChartPlugin().configure({ key: 'handlebars' }),
         ...experimentalplugins,
       ],
     });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
